### PR TITLE
Refacto - PUT becomes PATCH

### DIFF
--- a/src/main/java/fr/laurentFE/todolistspringbootserver/web/ServerController.java
+++ b/src/main/java/fr/laurentFE/todolistspringbootserver/web/ServerController.java
@@ -47,7 +47,7 @@ public class ServerController {
         return serverService.createUser(user);
     }
 
-    @PutMapping("/rest/users/{id}")
+    @PatchMapping("/rest/users/{id}")
     public User updateUser(@RequestBody @Valid User user, @PathVariable Integer id) {
         if (user.getUserId() != null) {
             throw new UnexpectedParameterException("userId");
@@ -93,7 +93,7 @@ public class ServerController {
         return serverService.createToDoList(toDoList);
     }
 
-    @PutMapping("/rest/toDoLists/{id}")
+    @PatchMapping("/rest/toDoLists/{id}")
     public ToDoList updateToDoList(@RequestBody @Valid ToDoList toDoList, @PathVariable Integer id) {
         if (toDoList.getListId() != null) {
             throw new UnexpectedParameterException("listId");
@@ -113,7 +113,7 @@ public class ServerController {
         return serverService.createItem(rItem);
     }
 
-    @PutMapping("/rest/items/{id}")
+    @PatchMapping("/rest/items/{id}")
     public Item updateItem(@RequestBody @Valid Item item, @PathVariable Integer id) {
         if (item.getItemId() != null) {
             throw new UnexpectedParameterException("itemId");


### PR DESCRIPTION
All PUT calls do not allow for "creation of resource or update if resource already exists", and are thus replaced by PATCH calls who better reflect the "update only" use case of these endpoints.