### PR TITLE
Refacto - Exception & Logging

### DIFF
--- a/src/main/java/fr/laurentFE/todolistspringbootserver/service/ServerService.java
+++ b/src/main/java/fr/laurentFE/todolistspringbootserver/service/ServerService.java
@@ -169,14 +169,16 @@ public class ServerService {
         toDoList.setListId(ul.getListId());
         ListName ln = listNameRepository.save(new ListName(null, toDoList.getLabel()));
         if (!ln.getListId().equals(toDoList.getListId())) {
-            logger.error("Out of sync creation of list_name list_id='{}' for list list_id='{}'",
-                    ln.getListId(),
-                    toDoList.getListId());
             logger.info("Deleting list_names entry for list_id='{}' following an out of sync ID error", ln.getListId());
             listNameRepository.delete(ln);
             logger.info("Deleting lists entry for list_id='{}' following an out of sync ID error", ul.getListId());
             userListRepository.delete(ul);
-            throw new OutOfSyncListIdsException("");
+            throw new OutOfSyncListIdsException(
+                    "Out of sync creation of list_name list_id='"
+                    + ln.getListId()
+                    + "' for list list_id='"
+                    + toDoList.getListId()
+                    + "'");
         }
         if (!toDoList.getItems().isEmpty()) {
             for (Item item : toDoList.getItems()) {

--- a/src/main/java/fr/laurentFE/todolistspringbootserver/web/CustomExceptionController.java
+++ b/src/main/java/fr/laurentFE/todolistspringbootserver/web/CustomExceptionController.java
@@ -2,6 +2,9 @@ package fr.laurentFE.todolistspringbootserver.web;
 
 import fr.laurentFE.todolistspringbootserver.model.ErrorResponse;
 import fr.laurentFE.todolistspringbootserver.model.exceptions.*;
+import fr.laurentFE.todolistspringbootserver.service.ServerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -14,6 +17,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 // Unhandled Exceptions are handled by the default /error resource
 @RestControllerAdvice
 public class CustomExceptionController {
+
+    Logger logger = LoggerFactory.getLogger(ServerService.class);
 
     @ExceptionHandler(UnexpectedParameterException.class)
     public ResponseEntity<ErrorResponse> handleUnexpectedParameterException(Exception e) {
@@ -78,6 +83,7 @@ public class CustomExceptionController {
     @ExceptionHandler(OutOfSyncListIdsException.class)
     public ResponseEntity<ErrorResponse> handleOutOfSyncListIdsException(Exception e) {
         HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        logger.error(e.getMessage());
         String message = "Internal server error";
         return new ResponseEntity<>(new ErrorResponse(status, message), status);
     }
@@ -85,6 +91,7 @@ public class CustomExceptionController {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(Exception e) {
         HttpStatus status = HttpStatus.BAD_REQUEST;
+        logger.debug(e.getMessage());
         String message = "Required request body is missing";
         return new ResponseEntity<>(new ErrorResponse(status, message), status);
     }


### PR DESCRIPTION
OutOfSyncListIdsException handling now logs the error with the Exception's message, instead of logging inside off the function throwing the exception.

HttpMessageNotReadableException now logs the message at the debug level.