### PR TITLE
Refacto - renaming AfterEach "setup" to "tearDown"

### DIFF
--- a/src/test/java/fr/laurentFE/todolistspringbootserver/repository/ItemRepositoryTests.java
+++ b/src/test/java/fr/laurentFE/todolistspringbootserver/repository/ItemRepositoryTests.java
@@ -20,7 +20,7 @@ public class ItemRepositoryTests {
     JdbcTemplate jdbcTemplate;
 
     @AfterEach
-    public void setup() {
+    public void tearDown() {
         jdbcTemplate.execute("DELETE FROM `list_names`;");
         jdbcTemplate.execute("DELETE FROM `list_items`;");
         jdbcTemplate.execute("DELETE FROM `items`;");

--- a/src/test/java/fr/laurentFE/todolistspringbootserver/repository/ListNameRepositoryTests.java
+++ b/src/test/java/fr/laurentFE/todolistspringbootserver/repository/ListNameRepositoryTests.java
@@ -27,7 +27,7 @@ public class ListNameRepositoryTests {
     JdbcTemplate jdbcTemplate;
 
     @AfterEach
-    public void setup() {
+    public void tearDown() {
         jdbcTemplate.execute("DELETE FROM `list_names`;");
         jdbcTemplate.execute("DELETE FROM `list_items`;");
         jdbcTemplate.execute("DELETE FROM `items`;");

--- a/src/test/java/fr/laurentFE/todolistspringbootserver/repository/UserListRepositoryTests.java
+++ b/src/test/java/fr/laurentFE/todolistspringbootserver/repository/UserListRepositoryTests.java
@@ -27,7 +27,7 @@ public class UserListRepositoryTests {
     JdbcTemplate jdbcTemplate;
 
     @AfterEach
-    public void setup() {
+    public void tearDown() {
         jdbcTemplate.execute("DELETE FROM `list_names`;");
         jdbcTemplate.execute("DELETE FROM `list_items`;");
         jdbcTemplate.execute("DELETE FROM `items`;");

--- a/src/test/java/fr/laurentFE/todolistspringbootserver/repository/UsersRepositoryTests.java
+++ b/src/test/java/fr/laurentFE/todolistspringbootserver/repository/UsersRepositoryTests.java
@@ -22,7 +22,7 @@ public class UsersRepositoryTests {
     JdbcTemplate jdbcTemplate;
 
     @AfterEach
-    public void setup() {
+    public void tearDown() {
         jdbcTemplate.execute("DELETE FROM `list_names`;");
         jdbcTemplate.execute("DELETE FROM `list_items`;");
         jdbcTemplate.execute("DELETE FROM `items`;");


### PR DESCRIPTION
Function called after each test to reset database was named "setup", when it logically is now called tearDown.
