### PR TITLE
Refacto - test - remove unused annotation

### DIFF
--- a/src/test/java/fr/laurentFE/todolistspringbootserver/service/ServerServiceTests.java
+++ b/src/test/java/fr/laurentFE/todolistspringbootserver/service/ServerServiceTests.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
@@ -21,7 +20,6 @@ import java.util.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-@SpringBootTest
 public class ServerServiceTests {
 
     @InjectMocks


### PR DESCRIPTION
Removed the SpringBootTest annotation for ServerServiceTests, as it doesn't need all the spring boot context and slows everything down for no reason