### PR TITLE
Feature - GET / displays API doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ command :
 
 The webserver will run on the machine, and you will be able to send requests to the API on this machine.
 
-The resources handled by the API will be described on the landing page of the server (Not implemented yet - So far the HTML documentation is generated in ```./target/generated-docs/index.html``` inside the packaged JAR file)
+The resources handled by the API are described on the landing page of the server. 
+
+The API documentation is also accessible in ```./target/generated-docs/index.html``` or inside the packaged JAR file in
+```BOOT-INF\classes\static\docs\index.html```
 
 Upon start of the application, the database is currently always reset to its empty state.
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,31 @@
 				</dependencies>
 			</plugin>
 			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>${maven-resources-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>copy-resources</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>
+								${project.build.outputDirectory}/static/docs
+							</outputDirectory>
+							<resources>
+								<resource>
+									<directory>
+										${project.build.directory}/generated-docs
+									</directory>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>

--- a/src/main/java/fr/laurentFE/todolistspringbootserver/web/ServerController.java
+++ b/src/main/java/fr/laurentFE/todolistspringbootserver/web/ServerController.java
@@ -9,6 +9,12 @@ import fr.laurentFE.todolistspringbootserver.model.exceptions.OverSizedStringPro
 import fr.laurentFE.todolistspringbootserver.model.exceptions.UnexpectedParameterException;
 import fr.laurentFE.todolistspringbootserver.service.ServerService;
 import jakarta.validation.Valid;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -20,9 +26,27 @@ public class ServerController {
     @Autowired
     private ServerService serverService;
 
+    Logger logger = LoggerFactory.getLogger(ServerService.class);
+
     @GetMapping("/")
     public String displayDocumentation() {
-        return "list available endpoints and usage";
+        ClassLoader cl = this.getClass().getClassLoader();
+        InputStream inputStream = cl.getResourceAsStream("classpath:/static/docs/index.html");
+        String basicMessage = "Welcome to the Java - Spring Boot - Todo list server. You should find all the API " +
+                "documentation in the folder target/generated-docs/index.html if you built this application from the " +
+                "sources, or in BOOT-INF\\classes\\static\\docs\\index.html inside of the JAR file.";
+        if (inputStream != null) {
+            try {
+                String str = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+                inputStream.close();
+                return str;
+            } catch (IOException e) {
+                logger.error("IOException during readAllBytes() from inputStream : classpath:/static/docs/index.html");
+                logger.error(e.getMessage());
+                return basicMessage;
+            }
+        }
+        return basicMessage;
     }
 
 

--- a/src/test/java/fr/laurentFE/todolistspringbootserver/web/ServerControllerE2ETests.java
+++ b/src/test/java/fr/laurentFE/todolistspringbootserver/web/ServerControllerE2ETests.java
@@ -101,8 +101,10 @@ public class ServerControllerE2ETests {
         this.mockMvc.perform(get("/"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("list available endpoints and usage")))
-                .andDo(document("home"));
+                .andExpect(content().string(containsString("Welcome to the Java - Spring Boot - Todo list " +
+                        "server. You should find all the API documentation in the folder " +
+                        "target/generated-docs/index.html if you built this application from the sources, or in " +
+                        "BOOT-INF\\classes\\static\\docs\\index.html inside of the JAR file.")));
     }
 
     @Test


### PR DESCRIPTION
Requesting GET on the root of the server displays the API documentation HTML file generated through AsciiDoc & the snippets generated from the tests.

A fallback default message is also included, in case this fails.