### PR TITLE
v1.1.0 - GET /rest/toDoLists calls change and do not require a request body anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ developed, the client's current version doesn't use the proper endpoints and req
 Currently available endpoints allow :
 - Restitution of all users
 - Restitution of all of a user's todo lists
-- Restitution of a user's specific todo list
+- Restitution of a specific todo list
 - Creation of a user 
 - Creation of a list for a user, with or without items
 - Creation of a list item for a list attached to a user

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>fr.laurentFE</groupId>
 	<artifactId>todolistspringbootserver</artifactId>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<name>Java-ToDoList-SpringBoot-Server</name>
 	<description>Java Spring Boot REST API server for a todo list application </description>
 	<url/>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -70,19 +70,10 @@ include::{snippets}/patchUsers/response-fields.adoc[]
 
 == ToDoLists endpoints
 
-=== GET /rest/toDoLists
-Provides the list of todo lists for a given userName
+=== GET /rest/toDoLists?userId=\{userId}
+Provides the list of todo lists for a given userId
 
-.request body of the request GET /rest/toDoLists
-include::{snippets}/getToDoLists/request-body.adoc[]
-
-.request fields
-[%collapsible]
-====
-include::{snippets}/getToDoLists/request-fields.adoc[]
-====
-
-.response body
+.response body of the request /rest/toDoLists?userId=1
 include::{snippets}/getToDoLists/response-body.adoc[]
 
 .response fields
@@ -92,18 +83,9 @@ include::{snippets}/getToDoLists/response-fields.adoc[]
 ====
 
 === GET /rest/toDoLists/\{listId}
-Provides the requested todo list for a given userName
+Provides the requested todo list
 
-.request body of the request GET /rest/toDoLists/2
-include::{snippets}/getToDoListsId/request-body.adoc[]
-
-.request fields
-[%collapsible]
-====
-include::{snippets}/getToDoListsId/request-fields.adoc[]
-====
-
-.response body
+.response body  of the request GET /rest/toDoLists/2
 include::{snippets}/getToDoListsId/response-body.adoc[]
 
 .response fields

--- a/src/main/java/fr/laurentFE/todolistspringbootserver/service/ServerService.java
+++ b/src/main/java/fr/laurentFE/todolistspringbootserver/service/ServerService.java
@@ -129,21 +129,13 @@ public class ServerService {
         return res;
     }
 
-    public ToDoList findSpecificToDoList(User user, Integer listId) {
-        User dbUser = findUser(user.getUserName());
-        Integer dbListUserId = jdbcTemplate.queryForObject(
-                "SELECT user_id FROM lists WHERE list_id=:listId",
-                new MapSqlParameterSource().addValue("listId", listId),
-                Integer.class);
-        if (!dbUser.getUserId().equals(dbListUserId)) {
-            throw new DataNotFoundException("(listId, userName)");
-        }
+    public ToDoList findSpecificToDoList(Integer listId) {
         return getFilledToDoList(listId);
     }
 
-    public Iterable<ToDoList> findAllToDoLists(User user) {
+    public Iterable<ToDoList> findAllToDoLists(Integer userId) {
         // dbUser cannot be null, as if no user is found from the given userName, an exception is thrown
-        User dbUser = findUser(user.getUserName());
+        User dbUser = findUser(userId);
         ArrayList<ToDoList> tdl = new ArrayList<>();
         Iterable<UserList> userList = userListRepository.findAllByUserId(dbUser.getUserId()).orElse(null);
         if (userList != null) {

--- a/src/main/java/fr/laurentFE/todolistspringbootserver/web/ServerController.java
+++ b/src/main/java/fr/laurentFE/todolistspringbootserver/web/ServerController.java
@@ -90,16 +90,13 @@ public class ServerController {
      * ToDoList endpoints
      */
     @GetMapping("/rest/toDoLists")
-    public Iterable<ToDoList> getToDoLists(@RequestBody @Valid User user) {
-        return serverService.findAllToDoLists(user);
+    public Iterable<ToDoList> getToDoLists(@RequestParam("userId") Integer userId) {
+        return serverService.findAllToDoLists(userId);
     }
 
     @GetMapping("/rest/toDoLists/{id}")
-    public ToDoList getToDoList(@RequestBody @Valid User user, @PathVariable Integer id) {
-        if(user.getUserId() != null) {
-            throw new UnexpectedParameterException("userId");
-        }
-        return serverService.findSpecificToDoList(user, id);
+    public ToDoList getToDoList(@PathVariable Integer id) {
+        return serverService.findSpecificToDoList(id);
     }
 
     @PostMapping("/rest/toDoLists")

--- a/src/test/java/fr/laurentFE/todolistspringbootserver/service/ServerServiceTests.java
+++ b/src/test/java/fr/laurentFE/todolistspringbootserver/service/ServerServiceTests.java
@@ -170,13 +170,6 @@ public class ServerServiceTests {
         List<Map<String, Object>> storedListOfItems = new ArrayList<>();
         ToDoList expectedToDoList = new ToDoList(listId, userId, label, new ArrayList<>());
 
-        when(usersRepository.findByUserName(userName))
-                .thenReturn(Optional.of(storedUser));
-        when(jdbcTemplate.queryForObject(
-                any(String.class),
-                any(MapSqlParameterSource.class),
-                any(Class.class)))
-                .thenReturn(listId);
         when(userListRepository.findById(listId))
                 .thenReturn(Optional.of(storedUserList));
         when(listNameRepository.findById(listId))
@@ -186,7 +179,7 @@ public class ServerServiceTests {
                 any(MapSqlParameterSource.class)))
                 .thenReturn(storedListOfItems);
 
-        ToDoList returnedToDoList = serverService.findSpecificToDoList(user, listId);
+        ToDoList returnedToDoList = serverService.findSpecificToDoList(listId);
 
         assertNotNull(returnedToDoList);
         assertEquals(expectedToDoList.getListId(), returnedToDoList.getListId());
@@ -196,32 +189,10 @@ public class ServerServiceTests {
     }
 
     @Test
-    public void ServerService_findSpecificToDoList_throwsDataNotFoundException() {
-        String userName = "Archibald";
-        User user = new User(null, userName);
-        Integer listId = 1;
-        Integer userId = 1;
-        User storedUser = new User(userId, userName);
-
-        when(usersRepository.findByUserName(userName))
-                .thenReturn(Optional.of(storedUser));
-        when(jdbcTemplate.queryForObject(
-                any(String.class),
-                any(MapSqlParameterSource.class),
-                any(Class.class)))
-                .thenReturn(0);
-
-        DataNotFoundException e = assertThrows(
-                DataNotFoundException.class,
-                () -> serverService.findSpecificToDoList(user, listId));
-        assertEquals("(listId, userName)", e.getMessage());
-    }
-
-    @Test
     public void ServerService_findAllToDoLists_returnsToDoListList() {
         String userName = "Archibald";
-        User user = new User(null, userName);
         Integer userId = 1;
+        User user = new User(userId, userName);
         User storedUser = new User(userId, userName);
         UserList storedUserList1 = new UserList(1, userId);
         UserList storedUserList2 = new UserList(2, userId);
@@ -237,7 +208,7 @@ public class ServerServiceTests {
         storedItems.put("item_id", 1);
         storedListOfItems.add(storedItems);
 
-        when(usersRepository.findByUserName(userName))
+        when(usersRepository.findById(userId))
                 .thenReturn(Optional.of(storedUser));
         when(userListRepository.findAllByUserId(storedUser.getUserId()))
                 .thenReturn(Optional.of(userListList));
@@ -256,7 +227,7 @@ public class ServerServiceTests {
         when(itemRepository.findById(1))
                 .thenReturn(Optional.of(storedItem));
 
-        ArrayList<ToDoList> returnedToDoLists = (ArrayList<ToDoList>) serverService.findAllToDoLists(user);
+        ArrayList<ToDoList> returnedToDoLists = (ArrayList<ToDoList>) serverService.findAllToDoLists(user.getUserId());
 
         assertNotNull(returnedToDoLists);
         assertFalse(returnedToDoLists.isEmpty());

--- a/src/test/java/fr/laurentFE/todolistspringbootserver/web/ServerControllerE2ETests.java
+++ b/src/test/java/fr/laurentFE/todolistspringbootserver/web/ServerControllerE2ETests.java
@@ -198,9 +198,8 @@ public class ServerControllerE2ETests {
     @Test
     public void ServerControllerE2E_getToDoLists_returnsListOfToDoList() throws Exception {
         final MockHttpServletRequestBuilder builder = MockMvcRequestBuilders
-                .get("/rest/toDoLists")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{ \"userName\": \"Archibald\" }");
+                .get("/rest/toDoLists?userId=1")
+                .contentType(MediaType.APPLICATION_JSON);
 
         mockMvc.perform(builder)
                 .andDo(MockMvcResultHandlers.print())
@@ -232,11 +231,7 @@ public class ServerControllerE2ETests {
                                     "&& @.checked == false )] " +
                         ")]").exists())
                 .andDo(document("getToDoLists",
-                        preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("userName").description("The user's name (max length:45)")
-                        ),
                         responseFields(
                                 fieldWithPath("[].listId").description("The todo list's id"),
                                 fieldWithPath("[].userId").description("The todo list's owner's userId"),

--- a/src/test/java/fr/laurentFE/todolistspringbootserver/web/ServerControllerTests.java
+++ b/src/test/java/fr/laurentFE/todolistspringbootserver/web/ServerControllerTests.java
@@ -24,6 +24,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.ArrayList;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -255,11 +256,10 @@ public class ServerControllerTests {
         toDoLists.add(list1);
         toDoLists.add(list2);
         final MockHttpServletRequestBuilder builder = MockMvcRequestBuilders
-                .get("/rest/toDoLists")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{ \"userName\": \"Archibald\" }");
+                .get("/rest/toDoLists?userId=1")
+                .contentType(MediaType.APPLICATION_JSON);
 
-        when(serverService.findAllToDoLists(any(User.class)))
+        when(serverService.findAllToDoLists(any(Integer.class)))
                 .thenReturn(toDoLists);
 
         mvc.perform(builder)
@@ -299,8 +299,7 @@ public class ServerControllerTests {
         mvc.perform(builder)
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message")
-                        .value("Invalid value 'null' for field 'userName' : This field cannot be empty;"));
+                .andExpect(status().reason(containsString("Required parameter 'userId' is not present.")));
     }
 
     @Test
@@ -322,7 +321,7 @@ public class ServerControllerTests {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{ \"userName\": \"Archibald\" }");
 
-        when(serverService.findSpecificToDoList(any(User.class), eq(1)))
+        when(serverService.findSpecificToDoList(eq(1)))
                 .thenReturn(list);
 
         mvc.perform(builder)
@@ -345,27 +344,13 @@ public class ServerControllerTests {
     }
 
     @Test
-    public void ServerController_getToDoListsById_throwsUnexpectedParameterException() throws Exception {
-        final MockHttpServletRequestBuilder builder = MockMvcRequestBuilders
-                .get("/rest/toDoLists/{id}", 1)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{ \"userId\": 1, \"userName\": \"Archibald\" }");
-
-        mvc.perform(builder)
-                .andDo(MockMvcResultHandlers.print())
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message")
-                        .value("Unexpected request JSON key : userId"));
-    }
-
-    @Test
     public void ServerController_getToDoListsById_throwsDataNotFoundException() throws Exception {
         final MockHttpServletRequestBuilder builder = MockMvcRequestBuilders
                 .get("/rest/toDoLists/{id}", 1)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{ \"userName\": \"Archibald\" }");
 
-        when(serverService.findSpecificToDoList(any(User.class), eq(1)))
+        when(serverService.findSpecificToDoList(eq(1)))
                 .thenThrow(new DataNotFoundException("(listId, userName)"));
 
         mvc.perform(builder)


### PR DESCRIPTION
GET /rest/toDoLists became GET /rest/toDoLists?{userId} and do not require a request body anymore.

GET /rest/toDoLists/{listId} doesn't require a request body anymore, and thus doesn't check if the listId is connected to the provided user either.

Tests have been updated (or deleted depending on the case) to reflect updated routes.